### PR TITLE
#130 Refatorando as rotas de produtor, e cadastro de comprador.

### DIFF
--- a/src/hortum/customer/urls.py
+++ b/src/hortum/customer/urls.py
@@ -4,8 +4,8 @@ from rest_framework import routers
 
 from . import viewsets
 
-router = routers.SimpleRouter(trailing_slash=False)
-router.register(r'', viewsets.CustomerRegistrationAPIView, basename='customer')
+routerRegister = routers.SimpleRouter()
+routerRegister.register(r'', viewsets.CustomerRegistrationAPIView, basename='customer')
 
 urlpatterns = [
-] + router.urls
+]

--- a/src/hortum/productor/urls.py
+++ b/src/hortum/productor/urls.py
@@ -4,9 +4,13 @@ from rest_framework import routers
 
 from . import viewsets
 
-router = routers.SimpleRouter(trailing_slash=False)
-router.register(r'', viewsets.ProductorRegistrationAPIView, basename='productor')
-router.register(r'list', viewsets.ProductorListAPIView, basename='teste')
+routerRegister = routers.SimpleRouter()
+routerRegister.register(r'', viewsets.ProductorRegistrationAPIView, basename='productor')
+
+router = routers.SimpleRouter()
+router.register(r'list', viewsets.ProductorListAPIView, basename='listProductors')
+slashless_router = routers.DefaultRouter(trailing_slash=False)
+slashless_router.registry = router.registry[:]
 
 urlpatterns = [
-] + router.urls
+] + slashless_router.urls + router.urls

--- a/src/hortum/productor/viewsets.py
+++ b/src/hortum/productor/viewsets.py
@@ -15,6 +15,9 @@ class ProductorRegistrationAPIView(GenericViewSet, mixins.CreateModelMixin):
 	queryset = Productor.objects.all()
 
 class ProductorListAPIView(GenericViewSet, mixins.ListModelMixin):
-       permission_classes = (permissions.IsAuthenticated,)
-       serializer_class = ProductorSerializer
-       queryset = Productor.objects.all()
+    '''
+    EndPoint para listar todos produtores e anúncios
+    '''
+    permission_classes = (permissions.IsAuthenticated,)
+    serializer_class = ProductorSerializer
+    queryset = Productor.objects.all()

--- a/src/hortum/users/urls.py
+++ b/src/hortum/users/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path, include
 
 from rest_framework import routers
+from ..productor.urls import routerRegister as productorRegister
+from ..customer.urls import routerRegister as customerRegister
 
 from . import viewsets
 
@@ -8,6 +10,6 @@ router = routers.SimpleRouter(trailing_slash=False)
 router.register(r'confirm', viewsets.UserListRetrieveAPIView, basename='user')
 
 urlpatterns = [
-    path('customer/', include('hortum.customer.urls')),
-    path('productor/', include('hortum.productor.urls')),
+    path('customer/', include(customerRegister.urls)),
+    path('productor/', include(productorRegister.urls)),
 ] + router.urls


### PR DESCRIPTION
## Descrição
-  Ajuste de rotas de produtor e comprador.

## Está consertando alguma issue aberta?
- #130

## Tarefas gerais realizadas
- Refatoração da rota para cadastro de produtor e comprador
- Especificação de rota para anúncios

## Alterações feitas

### 1. Agora o acesso ao cadastro de produtor e comprador será somente pelos endpoints `signup/productor` e `signup/customer`.

### 2. E o acesso para os produtores e anúncios será pelo endpoint `productor/list` , assim conseguindo todos os produtores e seus anúncios.