### PR TITLE
#96 [US09] - Excluir anúncio

### DIFF
--- a/src/hortum/announcement/models.py
+++ b/src/hortum/announcement/models.py
@@ -238,7 +238,7 @@ class Announcement(models.Model):
     idProductor = models.ForeignKey(Productor, on_delete=models.CASCADE, related_name='announcements')
     idPicture = models.ForeignKey(Picture, on_delete=models.CASCADE, null=True)
     likes = models.IntegerField(default=0)
-    name = models.CharField(max_length=30)
+    name = models.CharField(unique=True, max_length=30)
     type_of_product = models.CharField(max_length=200, choices=TYPE_OF_PRODUCTS_CHOICES, default='Outros')
     description = models.CharField(max_length=200)
     price = models.FloatField(default=0.0)

--- a/src/hortum/announcement/models.py
+++ b/src/hortum/announcement/models.py
@@ -238,7 +238,7 @@ class Announcement(models.Model):
     idProductor = models.ForeignKey(Productor, on_delete=models.CASCADE, related_name='announcements')
     idPicture = models.ForeignKey(Picture, on_delete=models.CASCADE, null=True)
     likes = models.IntegerField(default=0)
-    name = models.CharField(unique=True, max_length=30)
+    name = models.CharField(max_length=30)
     type_of_product = models.CharField(max_length=200, choices=TYPE_OF_PRODUCTS_CHOICES, default='Outros')
     description = models.CharField(max_length=200)
     price = models.FloatField(default=0.0)

--- a/src/hortum/announcement/serializer.py
+++ b/src/hortum/announcement/serializer.py
@@ -6,7 +6,7 @@ from ..users.models import User
 
 from ..picture.serializer import PictureSerializer
 
-class AnnouncementSerializer(serializers.ModelSerializer):
+class AnnouncementCreateSerializer(serializers.ModelSerializer):
     idPicture = PictureSerializer(many=True, read_only=True)
     email = serializers.EmailField(write_only=True)
 

--- a/src/hortum/announcement/serializer.py
+++ b/src/hortum/announcement/serializer.py
@@ -14,6 +14,12 @@ class AnnouncementSerializer(serializers.ModelSerializer):
         model = Announcement
         fields = ['email', 'idPicture', 'likes', 'name', 'type_of_product', 'description', 'price', 'inventory'] 
 
+    def validate(self, data):
+        productor = Productor.objects.get(user=User.objects.get(email=data['email']))
+        if productor.announcements.filter(name=data['name']).exists():
+            raise serializers.ValidationError({'name': 'Este nome de anúncio ja foi utilizado.'})
+        return data
+
     def create(self, validated_data):
         productor_pk = Productor.objects.get(user=User.objects.get(email=validated_data.pop('email')))
         announcement = Announcement.objects.create(idProductor=productor_pk, **validated_data)

--- a/src/hortum/announcement/tests.py
+++ b/src/hortum/announcement/tests.py
@@ -1,3 +1,79 @@
-from django.test import TestCase
+from rest_framework.test import APITestCase
 
-# Create your tests here.
+from ..productor.models import Productor
+from ..users.models import User
+from .models import Announcement
+
+class AnnouncementsDeleteAPIViewTestCase(APITestCase):
+    def create_user(self):
+        self.user_data = {
+	    "username": "João",
+            "email": "joao@teste.com",
+	    "password": "teste"
+        }
+
+        url_signup = '/signup/productor/'
+
+        response = self.client.post(
+            url_signup,
+	    {'user': self.user_data},
+	    format='json'
+	)
+        
+        self.assertEqual(response.status_code, 201, msg='Falha na criação de usuário')
+
+    def create_tokens(self):
+        user_cred = {'email': self.user_data['email'], 'password': self.user_data['password']}
+
+        url_token = '/login/'
+
+        response = self.client.post(
+            url_token,
+	    user_cred,
+	    format='json'
+        )
+
+        self.assertEqual(response.status_code, 200, msg='Credenciais inválidas')
+
+        self.creds = {'HTTP_AUTHORIZATION': 'Bearer ' + response.data['access']}
+
+    def create_announcement(self):
+        self.announcement_data = {
+            "email": self.user_data['email'],
+            "name": "Meio quilo de linguíça",
+            "type_of_product": "Linguiça artesanal e defumados",
+            "description": "Linquiça",
+            "price": 35.50
+        }
+
+        url_create_announ = '/announcement/create'
+
+        response = self.client.post(
+            path=url_create_announ,
+	    data=self.announcement_data,
+	    format='json',
+	    **self.creds
+        )
+
+        self.assertEqual(response.status_code, 201, msg='Falha na criação do anúncio')
+
+    def setUp(self):
+        self.create_user()
+        self.create_tokens()
+        self.create_announcement()
+
+        self.url_delete_announ = '/announcement/delete/' + self.announcement_data['name']
+
+    def tearDown(self):
+        Announcement.objects.all().delete()
+        Productor.objects.all().delete()
+        User.objects.all().delete()
+
+    def test_delete_announcement(self):
+        response = self.client.delete(
+            path=self.url_delete_announ,
+	    format='json',
+	    **self.creds
+        )
+
+        self.assertEqual(response.status_code, 204, msg='Falha na deleção do anúncio')

--- a/src/hortum/announcement/urls.py
+++ b/src/hortum/announcement/urls.py
@@ -6,7 +6,8 @@ from rest_framework import routers
 from . import viewsets
 
 router = routers.SimpleRouter(trailing_slash=False)
-router.register(r'create', viewsets.AnnouncementRegistrationAPIView, basename='announcement')
+router.register(r'create', viewsets.AnnouncementRegistrationAPIView, basename='createAnnoun')
+router.register(r'delete', viewsets.AnnouncementDeleteAPIView, basename='deleteAnnoun')
 
 urlpatterns = [
 ] + router.urls

--- a/src/hortum/announcement/viewsets.py
+++ b/src/hortum/announcement/viewsets.py
@@ -5,8 +5,7 @@ from ..productor.models import Productor
 from ..users.models import User
 
 from rest_framework.viewsets import GenericViewSet 
-from rest_framework import mixins, permissions, status
-from rest_framework.response import Response
+from rest_framework import mixins, permissions
 
 class AnnouncementRegistrationAPIView(GenericViewSet, mixins.CreateModelMixin):
     '''

--- a/src/hortum/announcement/viewsets.py
+++ b/src/hortum/announcement/viewsets.py
@@ -1,5 +1,4 @@
 from .serializer import AnnouncementSerializer
-
 from .models import Announcement
 
 from rest_framework.viewsets import GenericViewSet 
@@ -7,12 +6,12 @@ from rest_framework import mixins
 from rest_framework import permissions
 
 class AnnouncementRegistrationAPIView(GenericViewSet, mixins.CreateModelMixin):
-	'''
-	EndPoint para registro de anúncio
-	'''
-	permission_classes = (permissions.IsAuthenticated,)
-	serializer_class = AnnouncementSerializer
-	queryset = Announcement.objects.all()
+    '''
+    EndPoint para registro de anúncio
+    '''
+    permission_classes = (permissions.IsAuthenticated,)
+    serializer_class = AnnouncementSerializer
+    queryset = Announcement.objects.all()
 
 class AnnouncementDeleteAPIView(GenericViewSet, mixins.DestroyModelMixin):
     '''

--- a/src/hortum/announcement/viewsets.py
+++ b/src/hortum/announcement/viewsets.py
@@ -1,16 +1,19 @@
-from .serializer import AnnouncementSerializer
+from . import serializer 
 from .models import Announcement
 
+from ..productor.models import Productor
+from ..users.models import User
+
 from rest_framework.viewsets import GenericViewSet 
-from rest_framework import mixins
-from rest_framework import permissions
+from rest_framework import mixins, permissions, status
+from rest_framework.response import Response
 
 class AnnouncementRegistrationAPIView(GenericViewSet, mixins.CreateModelMixin):
     '''
     EndPoint para registro de anúncio
     '''
     permission_classes = (permissions.IsAuthenticated,)
-    serializer_class = AnnouncementSerializer
+    serializer_class = serializer.AnnouncementCreateSerializer
     queryset = Announcement.objects.all()
 
 class AnnouncementDeleteAPIView(GenericViewSet, mixins.DestroyModelMixin):
@@ -18,6 +21,9 @@ class AnnouncementDeleteAPIView(GenericViewSet, mixins.DestroyModelMixin):
     EndPoint para remoção de anúncio
     '''
     permission_classes = (permissions.IsAuthenticated,)
-    serializer_class = AnnouncementSerializer
-    queryset = Announcement.objects.all()
+    queryset = Productor.objects.all()
     lookup_field = 'name'
+
+    def get_queryset(self):
+        productor = Productor.objects.get(user=User.objects.get(email=self.request.user))
+        return productor.announcements.all()

--- a/src/hortum/announcement/viewsets.py
+++ b/src/hortum/announcement/viewsets.py
@@ -13,3 +13,12 @@ class AnnouncementRegistrationAPIView(GenericViewSet, mixins.CreateModelMixin):
 	permission_classes = (permissions.IsAuthenticated,)
 	serializer_class = AnnouncementSerializer
 	queryset = Announcement.objects.all()
+
+class AnnouncementDeleteAPIView(GenericViewSet, mixins.DestroyModelMixin):
+    '''
+    EndPoint para remoção de anúncio
+    '''
+    permission_classes = (permissions.IsAuthenticated,)
+    serializer_class = AnnouncementSerializer
+    queryset = Announcement.objects.all()
+    lookup_field = 'name'

--- a/src/hortum/customer/serializer.py
+++ b/src/hortum/customer/serializer.py
@@ -5,13 +5,13 @@ from ..users.models import User
 
 from ..users.serializer import UserSerializer
 from ..picture.serializer import PictureSerializer
-from ..announcement.serializer import AnnouncementSerializer
+from ..announcement.serializer import AnnouncementCreateSerializer
 from ..productor.serializer import ProductorSerializer
 
 class CustomerSerializer(serializers.ModelSerializer):
     user = UserSerializer(required=True)
     idPicture = PictureSerializer(many=False, read_only=True)
-    idAnunFav = AnnouncementSerializer(many=True, read_only=True)
+    idAnunFav = AnnouncementCreateSerializer(many=True, read_only=True)
     idProdFav = ProductorSerializer(many=True, read_only=True)
 
     class Meta:

--- a/src/hortum/productor/serializer.py
+++ b/src/hortum/productor/serializer.py
@@ -4,13 +4,13 @@ from .models import Productor, Localization
 from ..users.models import User
 
 from ..users.serializer import UserSerializer
-from ..announcement.serializer import AnnouncementSerializer
+from ..announcement.serializer import AnnouncementCreateSerializer
 from ..picture.serializer import PictureSerializer
 
 class ProductorSerializer(serializers.ModelSerializer):
     user = UserSerializer(required=True)
     idPicture = PictureSerializer(many=False, read_only=True)
-    announcements = AnnouncementSerializer(read_only=True, many=True)
+    announcements = AnnouncementCreateSerializer(read_only=True, many=True)
 
     class Meta:
         model = Productor


### PR DESCRIPTION
## Descrição
- Implementação do backend para exclusão de anúncios

## Está consertando alguma issue aberta?
- #95

## Tarefas gerais realizadas
- Alterado nome do serializer de anúncios de `AnnouncementSerializer` para `AnnouncementCreateSerializer`
- Adicionado viewset `AnnouncementDeleteAPIView` para deleção de anúncios
- Adicionado rota específica para a viewset
- Adicionado testes unitários

## Pull Requests relacionados
[#24](https://github.com/fga-eps-mds/2020.2-Hortum-Mobile/pull/24)

## Testando as alterações
### 1. Registre um novo anúncio (#93)

------------------------
### 2. Agora delete o anúncio utilizando a rota autenticada `announcement/delete/{nome do anúncio}`.
**Importante: é necessário utilizar o `token do produtor` que se deseja excluir o anúncio**
Se tudo ocorrer bem, será retornado o código `204` confirmando a remoção do anúncio.

------------------------
### 3. Para confirmar os anúncios, acesse o endpoint `productor/list` (#112)

------------------------
## Para rodar os testes unitários 
1. Ligue o docker-compose
2. Acesse o container do django
```bash
docker ps
docker exec -it {código do container} bash
```

3. Rode o código
```bash
python manage.py test
```

4. Cheque se todos os testes passaram
```bash
System check identified no issues (0 silenced).
.
----------------------------------------------------------------------
Ran 1 test in 0.279s

OK
Destroying test database for alias 'default'...
```