### PR TITLE
#97 [US11] - Procurar produto

### DIFF
--- a/src/hortum/announcement/tests.py
+++ b/src/hortum/announcement/tests.py
@@ -317,3 +317,36 @@ class AnnouncementsListAPIViewTestCase(APITestCase):
 
         self.assertEqual(response.status_code, 200, msg='Falha na listagem do anúncio')
         self.assertEqual(len(response.data), 1, msg='Falha na quantidade de anúncios listados')
+    
+    def test_list_names_multiples_annoucement(self):
+        self.url_list_announ += '/Meio'
+
+        response = self.client.get(
+            path=self.url_list_announ,
+            **self.creds
+        )
+
+        self.assertEqual(response.status_code, 200, msg='Nenhum anúncio com o nome inserido')
+        self.assertEqual(len(response.data), 2, msg='Falha na quantidade de anúncios listados')
+
+    def test_list_names_one_announcement(self):
+        self.url_list_announ += '/Meio quilo de linguíça'
+
+        response = self.client.get(
+            path=self.url_list_announ,
+            **self.creds
+        )
+
+        self.assertEqual(response.status_code, 200, msg='Nenhum anúncio encontrado')
+        self.assertEqual(len(response.data), 1, msg='Falha na busca por anúncio')
+
+    def test_list_containing_name_announcement(self):
+        self.url_list_announ += '/quilo de'
+
+        response = self.client.get(
+            path=self.url_list_announ,
+            **self.creds
+        )
+
+        self.assertEqual(response.status_code, 200, msg='Nenhum anúncio encontrado')
+        self.assertEqual(len(response.data), 2, msg='Falaha na busca por anúncio')

--- a/src/hortum/announcement/urls.py
+++ b/src/hortum/announcement/urls.py
@@ -5,7 +5,7 @@ from . import viewsets
 router = routers.SimpleRouter(trailing_slash=False)
 router.register(r'create', viewsets.AnnouncementRegistrationAPIView, basename='createAnnoun')
 router.register(r'update', viewsets.AnnouncementDeleteUpdateAPIView, basename='deleteUpdateAnnoun')
-router.register(r'list', viewsets.AnnouncementListAPIView, basename='listAnnoun')
+router.register(r'list(:?/(?P<announcementName>.+))?', viewsets.AnnouncementListAPIView, basename='listAnnoun')
 
 urlpatterns = [
 ] + router.urls

--- a/src/hortum/announcement/viewsets.py
+++ b/src/hortum/announcement/viewsets.py
@@ -37,6 +37,14 @@ class AnnouncementDeleteUpdateAPIView(GenericViewSet, mixins.DestroyModelMixin, 
         return context
 
 class AnnouncementListAPIView(GenericViewSet, mixins.ListModelMixin):
+    '''
+    EndPoint para listagem de anúncios em ordem crescente de nome
+    '''
     permission_classes = (permissions.IsAuthenticated,)
     serializer_class = serializer.AnnouncementListSerializer
-    queryset = Announcement.objects.filter(inventory=True)
+    
+    def get_queryset(self):
+        queryset = Announcement.objects.filter(inventory=True)
+        if self.kwargs:
+            queryset = queryset.filter(name__icontains=self.kwargs['announcementName'])
+        return queryset.order_by('name')


### PR DESCRIPTION
## Descrição
- Refatoração da viewsets e url de listagem de anúncios

## Está consertando alguma issue aberta?
- #97

## Tarefas gerais realizadas
- Modificação da rota `announcements/list` permitindo filtragem por nome de anúncio
- Implementado novos testes unitários/integração

## Pull Requests relacionados
- [#30](https://github.com/fga-eps-mds/2020.2-Hortum-Mobile/pull/30)

## Testando as alterações
### 1. Registre os anúncios necessários para testar (recomendado 2 ou 3 anúncios)
### 2. Acesse o endpoint `announcement/list` autenticado
#### 2.1 Caso queira pesquisar pelo nome de um anúncio específico: `announcement/list/{nome anúncio}`
#### 2.2 Caso queira todos os anúncios disponíveis: `announcement/list`

```json
[
    {
        "username": "username do produtor",
        "idPictureProductor": foto do produtor,
        "name": "nome do anúncio",
        "type_of_product": "tipo do produto",
        "description": "descrição do produto",
        "price": preço do produto,
        "idPicture": foto do produto
    },
    {
        "username": "username do produtor",
        "idPictureProductor": foto do produtor,
        "name": "nome do anúncio",
        "type_of_product": "tipo do produto",
        "description": "descrição do produto",
        "price": preço do produto,
        "idPicture": foto do produto
    }
]
```

## Testes unitários modificados/adicionados
- `test_list_name_multiples_announcements`: para testar busca de anúncios com o mesmo nome
- `test_list_name_one_announcements`: para buscar um anúncio específico
- `test_list_containing_name_announcements`: para buscar por anúncios com partes de nome