### PR TITLE
#192 implementação swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <a href="https://github.com/fga-eps-mds/2020.2-Hortum/actions/workflows/deploy.yml">
 		<img alt="Deploy status" src="https://github.com/fga-eps-mds/2020.2-Hortum/actions/workflows/deploy.yml/badge.svg?style=flat">
 		</a>
-	<a href="https://codeclimate.com/github/fga-eps-mds/2020.2-Hortum/maintainability%22%3E">
+	<a href="https://codeclimate.com/github/fga-eps-mds/2020.2-Hortum/maintainability">
 		<img src="https://api.codeclimate.com/v1/badges/2f0b4388e4d6fc55c27f/maintainability"/>
 		</a>
     <a href="https://codecov.io/gh/fga-eps-mds/2020.2-Hortum">

--- a/README.md
+++ b/README.md
@@ -8,14 +8,17 @@
 <!-- Badges -->
 <!-- (TODO) Adicionar as Badges de DevOps -->
 <p align="center">
-      	<a href="https://codecov.io/gh/fga-eps-mds/2020.2-Hortum">
-        	<img src="https://codecov.io/gh/fga-eps-mds/2020.2-Hortum/branch/main/graph/badge.svg?token=R7MI4CF8JV"/>
-      		</a>
-	<a href="https://github.com/fga-eps-mds/2020.2-Hortum/actions/workflows/deploy.yml">
+    <a href="https://github.com/fga-eps-mds/2020.2-Hortum/actions/workflows/deploy.yml">
 		<img alt="Deploy status" src="https://github.com/fga-eps-mds/2020.2-Hortum/actions/workflows/deploy.yml/badge.svg?style=flat">
 		</a>
+	<a href="https://codeclimate.com/github/fga-eps-mds/2020.2-Hortum/maintainability%22%3E">
+		<img src="https://api.codeclimate.com/v1/badges/2f0b4388e4d6fc55c27f/maintainability"/>
+		</a>
+    <a href="https://codecov.io/gh/fga-eps-mds/2020.2-Hortum">
+        <img src="https://codecov.io/gh/fga-eps-mds/2020.2-Hortum/branch/main/graph/badge.svg?token=R7MI4CF8JV"/>
+      	</a>
 	<a href="https://github.com/fga-eps-mds/2020.2-Hortum/issues?q=is%3Aissue+is%3Aclosed">
-        	 <img alt="GitHub closed issues" src="https://img.shields.io/github/issues-closed-raw/fga-eps-mds/2020.2-Hortum?style=flat">
+        <img alt="GitHub closed issues" src="https://img.shields.io/github/issues-closed-raw/fga-eps-mds/2020.2-Hortum?style=flat">
 		</a>
 	<a href="https://github.com/fga-eps-mds/2020.2-Hortum/pulls?q=is%3Apr+is%3Aclosed">
 		<img alt="GitHub closed pull requests" src="https://img.shields.io/github/issues-pr-closed-raw/fga-eps-mds/2020.2-Hortum?style=flat">
@@ -59,6 +62,10 @@
 #### [Slides](https://docs.google.com/presentation/d/1LPcu3EU9AnJIsrmF4KuUFmTl85_jbg21nd3B3bkKDvI/edit?usp=sharing)
 #### [Apresentação](https://drive.google.com/file/d/1pTRLDNsnZ4VCxlIdEfnUGkJpgglq8PEH/view?usp=sharing)
 <!-- TODO adicionar R2 -->
+
+<!-- Documentação API-->
+## Documentação API
+[Documentação Swagger](https://hortum-api.herokuapp.com/swagger/)
 
 <!-- Instalação -->
 ## Instalação

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ djangorestframework-simplejwt
 django_heroku
 gunicorn
 coverage
+drf-yasg

--- a/src/hortum/settings.py
+++ b/src/hortum/settings.py
@@ -47,6 +47,7 @@ THIRD_PARTY_APPS = [
     'rest_framework',
     'rest_framework.authtoken',
     'corsheaders',
+    'drf_yasg',
 ]
 
 LOCAL_APPS = [

--- a/src/hortum/urls.py
+++ b/src/hortum/urls.py
@@ -1,8 +1,26 @@
 from django.contrib import admin
 from django.urls import path, include
 from hortum.users import viewsets
+from django.conf.urls import url
 
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 from rest_framework_simplejwt.views import TokenRefreshView
+
+schema_view = get_schema_view(
+   openapi.Info(
+      title="Hortum API",
+      default_version='v0.5.5',
+      description="API do aplicativo Hortum",
+      terms_of_service="https://fga-eps-mds.github.io/2020.2-Hortum/CONTRIBUTING/",
+      contact=openapi.Contact(email="mdsgrupo6@gmail.com"),
+      license=openapi.License(name="GPLv3 License"),
+   ),
+   public=True,
+   permission_classes=(permissions.AllowAny,),
+)
+
 
 urlpatterns = [
     path('login/', viewsets.CustomTokenObtainPairView.as_view(), name='token_obtain_pair'),
@@ -14,4 +32,7 @@ urlpatterns = [
     path('productor/', include('hortum.productor.urls')),
     path('customer/', include('hortum.customer.urls')),
     path('users/', include('hortum.users.urls')),
+    url(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    url(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 ]


### PR DESCRIPTION
## Descrição
- Implementação do Swagger, ferramenta de documentação de API

## Está consertando alguma issue aberta?
- #192 

## Tarefas gerais realizadas
- Adição da rota para pegar a documentação de API do Swagger
- Adição do Link para acessar a documentação no ambiente de produção, no README
- Correção da Badge do code climate de maintainability

### Testando as implementações
- Para ter acesso a API, deve-se executar um docker-compose up localmente, e assim acessar a rota ` http://localhost:8000/swagger/ ` 
- Infelizmente o Link para a documentação em ambiente de produção só estará disponível após o deploy.
- A Badge estará no README, e levará a pagina do code climate referente a API do Hortum.
