### PR TITLE
#89 [US02] - Apagar conta

### DIFF
--- a/src/hortum/routers.py
+++ b/src/hortum/routers.py
@@ -10,3 +10,14 @@ class CustomUpdateRouter(SimpleRouter):
             initkwargs={}
         )
     ]
+
+class CustomDeleteRouter(SimpleRouter):
+    routes = [
+        Route(
+            url=r'^{prefix}/?$',
+            mapping={'delete': 'destroy'},
+            name='{basename}-destroy',
+            detail=False,
+            initkwargs={}
+        )
+    ]

--- a/src/hortum/users/serializer.py
+++ b/src/hortum/users/serializer.py
@@ -8,6 +8,18 @@ class UserSerializer(serializers.ModelSerializer):
         model = User
         fields = ['username', 'email', 'password', 'is_productor']
 
+class UserDeleteSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(required=True)
+
+    class Meta:
+        model = User
+        fields = ['password']
+
+    def validate_password(self, password):
+        if not self.context['user'].check_password(password):
+            raise serializers.ValidationError('Senha incorreta!')
+        return password
+
 class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
     def validate(self, attrs):
         data = super(CustomTokenObtainPairSerializer, self).validate(attrs)

--- a/src/hortum/users/tests.py
+++ b/src/hortum/users/tests.py
@@ -1,6 +1,8 @@
 from rest_framework.test import APITestCase
 
 from ..customer.models import Customer
+from ..productor.models import Productor
+from ..announcement.models import Announcement
 from .models import User
 
 class UserTokenObtainAPIViewTestCase(APITestCase):
@@ -333,3 +335,156 @@ class ChangePasswordViewTestCase(APITestCase):
     def tearDown(self):
         Customer.objects.all().delete()
         User.objects.all().delete()
+
+class DeleteUserAPIViewTestCase(APITestCase):
+    def create_customer(self):
+        self.customer_data = {
+	        "username": "Luís",
+            "email": "luis@teste.com",
+	        "password": "teste"
+        }
+
+        url_signup = '/signup/customer/'
+
+        response = self.client.post(
+            url_signup,
+	        {'user': self.customer_data},
+	        format='json'
+	    )
+
+        self.assertEqual(response.status_code, 201, msg='Erro na criação do customer')
+
+    def create_productor(self):
+        self.productor_data = {
+	        "username": "João",
+            "email": "joao@teste.com",
+	        "password": "teste"
+        }
+
+        url_signup = '/signup/productor/'
+
+        response = self.client.post(
+            url_signup,
+	        {'user': self.productor_data},
+	        format='json'
+	    )
+
+        self.assertEqual(response.status_code, 201, msg='Erro na criação do productor')
+
+    def create_announcements(self):
+        self.announcement = {
+            "name": "Meio quilo de linguíça",
+            "type_of_product": "Linguiça artesanal e defumados",
+            "description": "Linquiça",
+            "price": 35.50
+        }
+    
+        url_create_announ = '/announcement/create'
+
+        response = self.client.post(
+            path=url_create_announ,
+	        data=self.announcement,
+	        format='json',
+	        **self.creds
+        )
+
+        self.assertEqual(response.status_code, 201, msg='Falha na criação do anúncio')
+
+    def favorite_announcement(self):
+        fav_announ = {
+            'email': self.productor_data['email'],
+            'announcementName': self.announcement['name']
+        }
+
+        announcement_fav_url = '/customer/fav-announcement'
+
+        response = self.client.patch(
+            path=announcement_fav_url,
+            format='json',
+            data=fav_announ,
+            **self.creds
+        )
+
+        self.assertEqual(response.status_code, 200, msg='Falha no registro do favorito')
+
+    def create_tokens(self, user_data):
+        user_cred = {'email': user_data['email'], 'password': user_data['password']}
+
+        url_token = '/login/'
+
+        response = self.client.post(
+            url_token,
+	        user_cred,
+	        format='json'
+        )
+
+        self.creds = {'HTTP_AUTHORIZATION': 'Bearer ' + response.data['access']}
+
+    def setUp(self):
+        self.create_customer()
+        self.create_productor()
+        self.create_tokens(self.productor_data)
+        self.create_announcements()
+        self.create_tokens(self.customer_data)
+        self.favorite_announcement()
+
+        self.delete_user_url = '/users/delete'
+
+    def tearDown(self):
+        Customer.objects.all().delete()
+        Productor.objects.all().delete()
+        Announcement.objects.all().delete()
+
+    def test_delete_with_invalid_password_user(self):
+        delete_info = {
+            'password': 'invalid'
+        }
+
+        response = self.client.delete(
+            path=self.delete_user_url,
+            format='json',
+            data=delete_info,
+            **self.creds
+        )
+
+        self.assertEqual(response.status_code, 400, msg='Deleção correta do user')
+
+    def test_delete_valid_customer(self):
+        delete_info = {
+            'password': self.customer_data['password']
+        }
+
+        response = self.client.delete(
+            path=self.delete_user_url,
+            format='json',
+            data=delete_info,
+            **self.creds
+        )
+
+        self.assertEqual(response.status_code, 204, msg='Falha na deleção do user')
+
+    def test_delete_valid_productor(self):
+        self.create_tokens(self.productor_data)
+        delete_info = {
+            'password': self.productor_data['password']
+        }
+
+        response = self.client.delete(
+            path=self.delete_user_url,
+            format='json',
+            data=delete_info,
+            **self.creds
+        )
+
+        self.assertEqual(response.status_code, 204, msg='Falha na deleção do user')
+
+        self.create_tokens(self.customer_data)
+        list_fav_announcements_url = '/customer/favorites/announcements'
+        response = self.client.get(
+            path=list_fav_announcements_url,
+            format='json',
+            **self.creds
+        )
+
+        self.assertEqual(response.status_code, 200, msg='Falha na listagem de anúncios favoritos')
+        self.assertEqual(len(response.data['idAnunFav']), 0, msg='Falha na quantidade de anúncios listados')

--- a/src/hortum/users/urls.py
+++ b/src/hortum/users/urls.py
@@ -2,14 +2,17 @@ from django.urls import path, include
 
 from ..productor.urls import routerRegister as productorRegister
 from ..customer.urls import routerRegister as customerRegister
-from ..routers import CustomUpdateRouter
+from ..routers import CustomUpdateRouter, CustomDeleteRouter
 from . import viewsets
 
 router = CustomUpdateRouter()
 router.register(r'change-password', viewsets.ChangePasswordView, basename='changePasswordUser')
 router.register(r'update', viewsets.UpdateUserView, basename='updateUser')
 
+customRouter = CustomDeleteRouter()
+customRouter.register(r'delete', viewsets.UserDeleteAPIView, basename='deleteUser')
+
 urlpatterns = [
     path('customer/', include(customerRegister.urls)),
     path('productor/', include(productorRegister.urls)),
-] + router.urls
+] + router.urls + customRouter.urls

--- a/src/hortum/users/viewsets.py
+++ b/src/hortum/users/viewsets.py
@@ -1,5 +1,3 @@
-from . import serializer
-
 from rest_framework_simplejwt.views import TokenObtainPairView
 
 from .models import User

--- a/src/hortum/users/viewsets.py
+++ b/src/hortum/users/viewsets.py
@@ -3,10 +3,9 @@ from . import serializer
 from rest_framework_simplejwt.views import TokenObtainPairView
 
 from .models import User
+from . import serializer
 
-from .serializer import ChangePasswordSerializer, UpdateUserSerializer
-
-from rest_framework import permissions, mixins
+from rest_framework import permissions, mixins, status
 from rest_framework.viewsets import GenericViewSet
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
@@ -29,11 +28,33 @@ class CustomTokenObtainPairView(TokenObtainPairView):
     '''
     serializer_class = serializer.CustomTokenObtainPairSerializer
 
+class UserDeleteAPIView(GenericViewSet, mixins.DestroyModelMixin):
+    '''
+    EndPoint para deleção de usuários
+    '''
+    serializer_class = serializer.UserDeleteSerializer
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def get_object(self):
+        return User.objects.get(email=self.request.user)
+
+    def get_serializer_context(self):
+        context = super(UserDeleteAPIView, self).get_serializer_context()
+        context.update({'user': self.request.user})
+        return context
+
+    def destroy(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_destroy(instance)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
 class ChangePasswordView(GenericViewSet, mixins.UpdateModelMixin):
     """
     EndPoint para trocar a senha
     """
-    serializer_class = ChangePasswordSerializer
+    serializer_class = serializer.ChangePasswordSerializer
     permission_classes = (permissions.IsAuthenticated,)
 
     def get_object(self):
@@ -57,7 +78,7 @@ class UpdateUserView(GenericViewSet, mixins.UpdateModelMixin):
     '''
     EndPoint para trocar username e email
     '''
-    serializer_class = UpdateUserSerializer
+    serializer_class = serializer.UpdateUserSerializer
     permission_classes = (permissions.IsAuthenticated,)
 
     def get_object(self):


### PR DESCRIPTION
## Descrição
- Adicionando funcionalidade de deletar as contas de usuários (tanto produtor quanto consumidor)

## Está consertando alguma issue aberta?
- #89 

## Tarefas gerais realizadas
- Adição da viewset `UserDeleteAPIView` para deleção de usuários
- Novo custom router `CustomDeleteRouter` para métodos `DELETE`
- Nova rota `users/delete`
- Testes unitários e de integração

## Testando as alterações
### 1. Registre um productor

---------
### 2. Registre um customer

---------
### 3. Registre um ou mais anúncios para o productor 

---------
### 4. Favorite um desses anúncios com o customer

---------
### 5. Acesse a rota `users/delete` autenticada com o token de quem será apagado do banco, com o seguinte json no código no corpo da requisição 
```json
{
    'password': {senha do user}
}
```
Caso tudo de certo, o código `204` será retornado;
**OBS:** Caso o user que foi apagado for um productor, perceba que os anúncios dele também foram apagados.

---------
## Para rodar os testes unitários 
1. Ligue o docker-compose

2. Rode o código de testes (-v 2 para o verbose) apenas do `User`
```bash
docker exec 20202-hortum_web_1 bash -c "python manage.py test hortum.users.tests.DeleteUserAPIViewTestCase -v 2"
```
2. Caso queira rodar todos os testes com o coverage
```bash
docker exec 20202-hortum_web_1 bash -c "coverage run manage.py test && coverage report -m && coverage erase"
```

3. Cheque se todos os testes passaram
```bash
System check identified no issues (0 silenced).
test_delete_valid_customer (hortum.users.tests.DeleteUserAPIViewTestCase) ... ok
test_delete_valid_productor (hortum.users.tests.DeleteUserAPIViewTestCase) ... ok
test_delete_with_invalid_password_user (hortum.users.tests.DeleteUserAPIViewTestCase) ... ok

----------------------------------------------------------------------
Ran 3 tests in 2.299s

OK
Destroying test database for alias 'default' ('test_hortum')...
```