### PR TITLE
#100 [US14] - Pesquisar Localização

### DIFF
--- a/src/hortum/announcement/tests.py
+++ b/src/hortum/announcement/tests.py
@@ -464,7 +464,7 @@ class AnnouncementsListAPIViewTestCase(APITestCase):
         self.assertEqual(len(response.data), 2, msg='Falha na busca por anúncio')
 
     def test_list_locals_multiples_annoucement(self):
-        self.filter_option += 'localizations'
+        self.filter_option += 'localizations__adress'
         self.value_option += 'local 1'
         self.url_list_announ += self.filter_option + self.value_option
 
@@ -477,7 +477,7 @@ class AnnouncementsListAPIViewTestCase(APITestCase):
         self.assertEqual(len(response.data), 2, msg='Falha na quantidade de anúncios listados')
 
     def test_list_local_one_announcement(self):
-        self.filter_option += 'localizations'
+        self.filter_option += 'localizations__adress'
         self.value_option += 'local 2'
         self.url_list_announ += self.filter_option + self.value_option
 
@@ -490,7 +490,7 @@ class AnnouncementsListAPIViewTestCase(APITestCase):
         self.assertEqual(len(response.data), 1, msg='Falha na busca por anúncio')
 
     def test_list_containing_local_announcement(self):
-        self.filter_option += 'localizations'
+        self.filter_option += 'localizations__adress'
         self.value_option += 'local'
         self.url_list_announ += self.filter_option + self.value_option
 

--- a/src/hortum/announcement/tests.py
+++ b/src/hortum/announcement/tests.py
@@ -336,7 +336,9 @@ class AnnouncementsListAPIViewTestCase(APITestCase):
             "type_of_product": "Linguiça artesanal e defumados",
             "description": "Linquiça",
             "price": 35.50,
-            "localizations": [],
+            "localizations": [
+                "local 1"
+            ],
             "images": []
         }
     
@@ -345,7 +347,10 @@ class AnnouncementsListAPIViewTestCase(APITestCase):
             "type_of_product": "Linguiça artesanal e defumados",
             "description": "Defumados",
             "price": 10.15,
-            "localizations": [],
+            "localizations": [
+                "local 1",
+                "local 2"
+            ],
             "images": []
         }
 
@@ -391,6 +396,8 @@ class AnnouncementsListAPIViewTestCase(APITestCase):
         self.create_announcement()
 
         self.url_list_announ = '/announcement/list'
+        self.filter_option = '/?filter='
+        self.value_option = '&value='
 
     def tearDown(self):
         Announcement.objects.all().delete()
@@ -418,7 +425,9 @@ class AnnouncementsListAPIViewTestCase(APITestCase):
         self.assertEqual(len(response.data), 1, msg='Falha na quantidade de anúncios listados')
     
     def test_list_names_multiples_annoucement(self):
-        self.url_list_announ += '/Meio'
+        self.filter_option += 'name'
+        self.value_option += 'Meio'
+        self.url_list_announ += self.filter_option + self.value_option
 
         response = self.client.get(
             path=self.url_list_announ,
@@ -429,7 +438,9 @@ class AnnouncementsListAPIViewTestCase(APITestCase):
         self.assertEqual(len(response.data), 2, msg='Falha na quantidade de anúncios listados')
 
     def test_list_names_one_announcement(self):
-        self.url_list_announ += '/Meio quilo de linguíça'
+        self.filter_option += 'name'
+        self.value_option += 'Meio quilo de linguíça'
+        self.url_list_announ += self.filter_option + self.value_option
 
         response = self.client.get(
             path=self.url_list_announ,
@@ -440,7 +451,9 @@ class AnnouncementsListAPIViewTestCase(APITestCase):
         self.assertEqual(len(response.data), 1, msg='Falha na busca por anúncio')
 
     def test_list_containing_name_announcement(self):
-        self.url_list_announ += '/quilo de'
+        self.filter_option += 'name'
+        self.value_option += 'quilo de'
+        self.url_list_announ += self.filter_option + self.value_option
 
         response = self.client.get(
             path=self.url_list_announ,
@@ -449,6 +462,81 @@ class AnnouncementsListAPIViewTestCase(APITestCase):
 
         self.assertEqual(response.status_code, 200, msg='Nenhum anúncio encontrado')
         self.assertEqual(len(response.data), 2, msg='Falha na busca por anúncio')
+
+    def test_list_locals_multiples_annoucement(self):
+        self.filter_option += 'localizations'
+        self.value_option += 'local 1'
+        self.url_list_announ += self.filter_option + self.value_option
+
+        response = self.client.get(
+            path=self.url_list_announ,
+            **self.creds
+        )
+
+        self.assertEqual(response.status_code, 200, msg='Nenhum anúncio com o nome inserido')
+        self.assertEqual(len(response.data), 2, msg='Falha na quantidade de anúncios listados')
+
+    def test_list_local_one_announcement(self):
+        self.filter_option += 'localizations'
+        self.value_option += 'local 2'
+        self.url_list_announ += self.filter_option + self.value_option
+
+        response = self.client.get(
+            path=self.url_list_announ,
+            **self.creds
+        )
+
+        self.assertEqual(response.status_code, 200, msg='Nenhum anúncio encontrado')
+        self.assertEqual(len(response.data), 1, msg='Falha na busca por anúncio')
+
+    def test_list_containing_local_announcement(self):
+        self.filter_option += 'localizations'
+        self.value_option += 'local'
+        self.url_list_announ += self.filter_option + self.value_option
+
+        response = self.client.get(
+            path=self.url_list_announ,
+            **self.creds
+        )
+
+        self.assertEqual(response.status_code, 200, msg='Nenhum anúncio encontrado')
+        self.assertEqual(len(response.data), 2, msg='Falha na busca por anúncio')
+
+    def test_list_invalid_query_params_announcement(self):
+        self.filter_option += 'name'
+        self.url_list_announ += self.filter_option
+
+        response = self.client.get(
+            path=self.url_list_announ,
+            **self.creds
+        )
+
+        self.assertEqual(response.status_code, 404, msg='Opção válida para busca')
+
+    def test_list_tree_query_params_announcement(self):
+        self.filter_option += 'name'
+        self.value_option += 'invalid'
+        third_option = '&third=invalid'
+        self.url_list_announ += self.filter_option + self.value_option + third_option
+
+        response = self.client.get(
+            path=self.url_list_announ,
+            **self.creds
+        )
+
+        self.assertEqual(response.status_code, 404, msg='Quantidade válida para busca')
+
+    def test_list_invalid_filter_announcement(self):
+        self.filter_option += 'invalid'
+        self.value_option += 'invalid'
+        self.url_list_announ += self.filter_option + self.value_option
+
+        response = self.client.get(
+            path=self.url_list_announ,
+            **self.creds
+        )
+
+        self.assertEqual(response.status_code, 400, msg='Filtro válido para busca')
 
     def test_announcement_order(self):
         response = self.client.get(

--- a/src/hortum/announcement/urls.py
+++ b/src/hortum/announcement/urls.py
@@ -1,12 +1,15 @@
 from rest_framework import routers
 
 from . import viewsets
+from ..routers import CustomListRouter
 
 router = routers.SimpleRouter(trailing_slash=False)
 router.register(r'create', viewsets.AnnouncementRegistrationAPIView, basename='createAnnoun')
 router.register(r'update', viewsets.AnnouncementDeleteUpdateAPIView, basename='deleteUpdateAnnoun')
-router.register(r'list(:?/(?P<announcementName>.+))?', viewsets.AnnouncementListAPIView, basename='listAnnoun')
 router.register(r'retrieve/(?P<encoded_email>.+)', viewsets.AnnouncementProductorListAPIView, basename='retrieveAnnounProd')
 
+listRouter = CustomListRouter()
+listRouter.register(r'list', viewsets.AnnouncementListAPIView, basename='listAnnoun')
+
 urlpatterns = [
-] + router.urls
+] + router.urls + listRouter.urls

--- a/src/hortum/announcement/viewsets.py
+++ b/src/hortum/announcement/viewsets.py
@@ -55,7 +55,7 @@ class AnnouncementListAPIView(GenericViewSet, mixins.ListModelMixin):
         if 'filter' and 'value' not in query_params or len(query_params) != 2:
             raise NotFound({'query_params': 'Parametros passados para a query incoerentes'})
         if query_params.get('filter') in possible_filters:
-            return queryset.filter(**{query_params.get('filter') + '__icontains': query_params.get('value')}).distinct()
+            return queryset.filter(**{'%s__icontains' % (query_params.get('filter')): query_params.get('value')}).distinct()
         raise ParseError({'filter': 'Campo para filtragem inexistente'})
 
 class AnnouncementProductorListAPIView(GenericViewSet, mixins.ListModelMixin):

--- a/src/hortum/announcement/viewsets.py
+++ b/src/hortum/announcement/viewsets.py
@@ -54,7 +54,7 @@ class AnnouncementListAPIView(GenericViewSet, mixins.ListModelMixin):
             return queryset
         if 'filter' and 'value' not in query_params or len(query_params) != 2:
             raise NotFound({'query_params': 'Parametros passados para a query incoerentes'})
-        if query_params.get('filter') in possible_filters: 
+        if query_params.get('filter') in possible_filters:
             return queryset.filter(**{query_params.get('filter') + '__icontains': query_params.get('value')}).distinct()
         raise ParseError({'filter': 'Campo para filtragem inexistente'})
 

--- a/src/hortum/announcement/viewsets.py
+++ b/src/hortum/announcement/viewsets.py
@@ -49,11 +49,12 @@ class AnnouncementListAPIView(GenericViewSet, mixins.ListModelMixin):
     def get_queryset(self):
         queryset = Announcement.objects.filter(inventory=True)
         query_params = self.request.GET
+        possible_filters = ['name', 'localizations__adress']
         if len(query_params) == 0:
             return queryset
         if 'filter' and 'value' not in query_params or len(query_params) != 2:
             raise NotFound({'query_params': 'Parametros passados para a query incoerentes'})
-        if query_params.get('filter') in ['name', 'localizations__adress']: 
+        if query_params.get('filter') in possible_filters: 
             return queryset.filter(**{query_params.get('filter') + '__icontains': query_params.get('value')}).distinct()
         raise ParseError({'filter': 'Campo para filtragem inexistente'})
 

--- a/src/hortum/announcement/viewsets.py
+++ b/src/hortum/announcement/viewsets.py
@@ -41,7 +41,7 @@ class AnnouncementDeleteUpdateAPIView(GenericViewSet, mixins.DestroyModelMixin, 
 
 class AnnouncementListAPIView(GenericViewSet, mixins.ListModelMixin):
     '''
-	EndPoint para listagem de anúncios em ordem crescente de nome
+	EndPoint para listagem de anúncios de acordo com o filtro e o valor passados
 	'''
     permission_classes = (permissions.IsAuthenticated,)
     serializer_class = serializer.AnnouncementListSerializer
@@ -53,10 +53,8 @@ class AnnouncementListAPIView(GenericViewSet, mixins.ListModelMixin):
             return queryset
         if 'filter' and 'value' not in query_params or len(query_params) != 2:
             raise NotFound({'query_params': 'Parametros passados para a query incoerentes'})
-        if query_params.get('filter') == 'name':
-            return queryset.filter(name__icontains=self.request.query_params.get('value'))
-        elif query_params.get('filter') == 'localizations':
-            return queryset.filter(localizations__adress__icontains=self.request.query_params.get('value')).distinct()
+        if query_params.get('filter') in ['name', 'localizations__adress']: 
+            return queryset.filter(**{query_params.get('filter') + '__icontains': query_params.get('value')}).distinct()
         raise ParseError({'filter': 'Campo para filtragem inexistente'})
 
 class AnnouncementProductorListAPIView(GenericViewSet, mixins.ListModelMixin):

--- a/src/hortum/announcement/viewsets.py
+++ b/src/hortum/announcement/viewsets.py
@@ -6,7 +6,7 @@ from ..users.models import User
 
 from rest_framework.viewsets import GenericViewSet
 from rest_framework import mixins, permissions
-from rest_framework.exceptions import ParseError
+from rest_framework.exceptions import ParseError, NotFound
 
 from ..encode import decode_string
 
@@ -48,9 +48,16 @@ class AnnouncementListAPIView(GenericViewSet, mixins.ListModelMixin):
 	
     def get_queryset(self):
         queryset = Announcement.objects.filter(inventory=True)
-        if self.kwargs:
-            queryset = queryset.filter(name__icontains=self.kwargs['announcementName'])
-        return queryset
+        query_params = self.request.GET
+        if len(query_params) == 0:
+            return queryset
+        if 'filter' and 'value' not in query_params or len(query_params) != 2:
+            raise NotFound({'query_params': 'Parametros passados para a query incoerentes'})
+        if query_params.get('filter') == 'name':
+            return queryset.filter(name__icontains=self.request.query_params.get('value'))
+        elif query_params.get('filter') == 'localizations':
+            return queryset.filter(localizations__adress__icontains=self.request.query_params.get('value')).distinct()
+        raise ParseError({'filter': 'Campo para filtragem inexistente'})
 
 class AnnouncementProductorListAPIView(GenericViewSet, mixins.ListModelMixin):
     permission_classes = (permissions.IsAuthenticated,)

--- a/src/hortum/routers.py
+++ b/src/hortum/routers.py
@@ -1,5 +1,23 @@
 from rest_framework.routers import SimpleRouter, Route
 
+class CustomListRouter(SimpleRouter):
+    routes = [
+        Route(
+            url=r'^{prefix}/{lookup}?$',
+            mapping={'get': 'list'},
+            name='{basename}-list',
+            detail=False,
+            initkwargs={}
+        ),
+        Route(
+            url=r'^{prefix}?$',
+            mapping={'get': 'list'},
+            name='{basename}-list',
+            detail=False,
+            initkwargs={}
+        )
+    ]
+
 class CustomUpdateRouter(SimpleRouter):
     routes = [
         Route(

--- a/src/hortum/routers.py
+++ b/src/hortum/routers.py
@@ -3,14 +3,14 @@ from rest_framework.routers import SimpleRouter, Route
 class CustomListRouter(SimpleRouter):
     routes = [
         Route(
-            url=r'^{prefix}/{lookup}?$',
+            url=r'^{prefix}/{lookup}/?$',
             mapping={'get': 'list'},
             name='{basename}-list',
             detail=False,
             initkwargs={}
         ),
         Route(
-            url=r'^{prefix}?$',
+            url=r'^{prefix}/?$',
             mapping={'get': 'list'},
             name='{basename}-list',
             detail=False,


### PR DESCRIPTION
## Descrição
- Possibilidade de pesquisar anúncios pelas suas localizações

## Está consertando alguma issue aberta?
- #100

## Tarefas gerais realizadas
- Alteração da rota `announcement/list` possibilitando passagem de parâmetros
- Adição de novo custom router para listagem
- Refatoração da viewset `AnnouncementListAPIView`

## Como testar as alterações
1. Crie um produtor
2. Crie um anúncio
3. Crie um consumidor
4. Acesse a rota `announcement/list`, aqui temos 5 possibilidades:
    1. Não passando nenhum parâmetro e recebendo todos os anúncios
    2. Passando a seguinte query `announcement/list?filter=name&value={nome do anúncio a ser procurado}`, retornando todos os anúncios que contem parte do nome inserido
    3. Passando a seguinte query `announcement/list?filter=localizations__adress&value={nome do local do anúncio a ser procurado}`, retornando todos os anúncios que contem parte do nome do local inserido
    4. Passando mais de 2 atributos na query ou os atributos não sendo `filter` e `value`, você ira receber um `404`
    5. Passando um `filter` inválido, você receberá um `400`